### PR TITLE
Fix parsing LDK

### DIFF
--- a/apq2gpx.pl
+++ b/apq2gpx.pl
@@ -2,7 +2,7 @@
 #
 # flipflip's AlpineQuest (https://www.alpinequest.net/) tools
 #
-# Copyright (c) 2017-2022 Philippe Kehl <flipflip at oinkzwurgl dot org>
+# Copyright (c) 2017-2022 Philippe Kehl <flipflip at oinkzwurgl dot org> and contributors
 #
 # apqtool is free software: you can redistribute it and/or modify it under the terms of the GNU
 # General Public License as published by the Free Software Foundation, either version 3 of the
@@ -808,7 +808,7 @@ package ApqFile
         }
 
         # data
-        $data .= $self->_getval('raw', $hdr->{size});
+        $data .= $self->_getval('bin', $hdr->{size});
 
         # additional data?
         if ($hdr->{addOffset})
@@ -846,7 +846,7 @@ package ApqFile
         }
 
         # additional data
-        my $addData = $self->_getval('raw', $hdr->{size});
+        my $addData = $self->_getval('bin', $hdr->{size});
         return undef unless (defined $addData);
         $data .= $addData;
 
@@ -925,21 +925,21 @@ package ApqFile
             $value = unpack('d>', $raw);
             $self->{rawoffs} += 8;
         }
-        elsif ($type eq 'int+raw') # size int + "raw" data
+        elsif ($type eq 'int+raw') # size int + "raw" data, return data as base64 encoded
         {
             my $size = $self->_getval('int');
             $raw = substr($self->{rawdata}, $self->{rawoffs}, $size);
             $value = MIME::Base64::encode_base64($raw, '');
             $self->{rawoffs} += $size;
         }
-        elsif ($type eq 'raw') # "raw" binary data of given size
+        elsif ($type eq 'raw') # "raw" binary data of given size, return data as base64 encoded
         {
             my $size = $arg;
             $raw = substr($self->{rawdata}, $self->{rawoffs}, $size);
-            $value = $raw;
+            $value = MIME::Base64::encode_base64($raw, '');
             $self->{rawoffs} += $size;
         }
-        elsif ($type eq 'bin') # binary data of given size
+        elsif ($type eq 'bin') # binary data of given size, return data as-is
         {
             my $size = $arg;
             $raw = substr($self->{rawdata}, $self->{rawoffs}, $size);

--- a/apq2gpx.pl
+++ b/apq2gpx.pl
@@ -2,7 +2,7 @@
 #
 # flipflip's AlpineQuest (https://www.alpinequest.net/) tools
 #
-# Copyright (c) 2017-2022 Philippe Kehl <flipflip at oinkzwurgl dot org> and contributors
+# Copyright (c) 2017-2024 Philippe Kehl <flipflip at oinkzwurgl dot org> and contributors
 #
 # apqtool is free software: you can redistribute it and/or modify it under the terms of the GNU
 # General Public License as published by the Free Software Foundation, either version 3 of the
@@ -833,7 +833,7 @@ package ApqFile
         # - *        byte data
 
         # header
-        $self->_seek($offset);
+        #$self->_seek($offset); # FIXME: maybe required? See https://github.com/phkehl/apq2gpx/pull/3
         my $hdr = $self->_getvalmulti(magic => 'int', size => 'long', addOffset => 'pointer');
         return undef unless (defined $hdr->{addOffset});
 

--- a/apq2gpx.pl
+++ b/apq2gpx.pl
@@ -833,6 +833,7 @@ package ApqFile
         # - *        byte data
 
         # header
+        $self->_seek($offset);
         my $hdr = $self->_getvalmulti(magic => 'int', size => 'long', addOffset => 'pointer');
         return undef unless (defined $hdr->{addOffset});
 
@@ -935,7 +936,7 @@ package ApqFile
         {
             my $size = $arg;
             $raw = substr($self->{rawdata}, $self->{rawoffs}, $size);
-            $value = MIME::Base64::encode_base64($raw, '');
+            $value = $raw;
             $self->{rawoffs} += $size;
         }
         elsif ($type eq 'bin') # binary data of given size


### PR DESCRIPTION
1. Seek offset while parsing node additional data
Without this change it just tried to parse consequent data blocks as AdditionalData and failed ("wrong magic") when found something different. Looks like someone missed it by occasion.

2. Disable base64-encoding raw blocks.
Because of this the node data (composed from the main and additional data blocks) was a concatenation of independent byte64-encoded chunks. That, in turn, broke any attempts of base64 decoding, but even worse, it broke deducing the file type (TRK, SET etc) from the first byte of data.
Before my fix, parsing the LDK file just gave a bunch of .bin files with unparsable base64. After the fix, the code successfully parsed a bunch of SET files and finished correctly.
This base64 encoding has been added here intentionally, howewer, I cannot understand any purpose of it.